### PR TITLE
feat: enable ogre LLM provider

### DIFF
--- a/miniogre/config.py
+++ b/miniogre/config.py
@@ -1,10 +1,12 @@
 import os
 import platform
+
 from dotenv import load_dotenv
+
 from .constants import *
 
-
 load_dotenv()
+
 
 def config_ogre_dir(ogre_dir):
     """
@@ -15,6 +17,7 @@ def config_ogre_dir(ogre_dir):
         os.makedirs(ogre_dir)
 
     return ogre_dir
+
 
 def _run_welcome(project_path, product, version, ogre_dir, date):
 
@@ -33,25 +36,27 @@ def _run_welcome(project_path, product, version, ogre_dir, date):
         echo REPOSITORY = {} 
         echo COMMIT = {}
         echo COMMIT_AUTHOR = {} 
-        """.format(repo[:-1], commit, author)
+        """.format(
+        repo[:-1], commit, author
+    )
 
     with open("{}/bashrc".format(ogre_dir), "a") as f:
         f.write(BOILERPLATE)
     f.close()
 
-def config_bashrc(project_dir, ogre_dir, product, version, date):
 
+def config_bashrc(project_dir, ogre_dir, product, version, date):
     """
     Check for existence of bashrc. If it exists, nothing is done. If it
     doesn't, it is created.
     """
 
     if os.path.isfile("{}/bashrc".format(project_dir)):
-        #print("   bashrc exists in {}".format(project_dir))
+        # print("   bashrc exists in {}".format(project_dir))
         os.popen("cp {}/bashrc {}/bashrc".format(project_dir, ogre_dir))
 
     else:
-        #print("   bashrc doesn't exist. Making a new one for you.")
+        # print("   bashrc doesn't exist. Making a new one for you.")
         with open("{}/bashrc".format(ogre_dir), "w") as f:
             f.write(BASHRC)
         f.close()
@@ -59,22 +64,34 @@ def config_bashrc(project_dir, ogre_dir, product, version, date):
 
     return os.path.isfile("{}/bashrc".format(ogre_dir))
 
-def config_dockerfile(project_dir, project_name, ogre_dir,
-                      baseimage, dry = False):
+
+def config_bashrc_baseimage(ogre_dir):
+    """
+    Create simple bashrc.
+    """
+
+    with open("{}/bashrc".format(ogre_dir), "w") as f:
+        f.write(BASHRC)
+    f.close()
+
+    return os.path.isfile("{}/bashrc".format(ogre_dir))
+
+
+def config_dockerfile(
+    project_dir, project_name, ogre_dir, baseimage, dry=False, base=False
+):
     """
     Check for existence of Dockerfile. If it exists, nothing is done. If it
     doesn't, a new Dockerfile is generate following the parameters in the
     config file.
     """
 
-    REQUIREMENTS_LINE = 'RUN cat ./{}/requirements.txt | xargs -L 1 uv pip install --system; exit 0'.format(os.path.basename(ogre_dir))
+    REQUIREMENTS_LINE = "RUN cat ./{}/requirements.txt | xargs -L 1 uv pip install --system; exit 0".format(
+        os.path.basename(ogre_dir)
+    )
 
     if dry:
-        print(
-            "Dry build -- no requirements will be installed {}".format(
-                baseimage
-            )
-        )
+        print("Dry build -- no requirements will be installed {}".format(baseimage))
 
         dockerfile_string = DOCKERFILE_DRY
 
@@ -86,7 +103,21 @@ def config_dockerfile(project_dir, project_name, ogre_dir,
             f.seek(0, 0)
             f.write("FROM {}".format(baseimage) + content)
         f.close()
-    
+
+    if base:
+        print("Building baseimage.")
+
+        dockerfile_string = DOCKERFILE_BASEIMAGE
+
+        with open("{}/Dockerfile".format(ogre_dir), "w") as f:
+            f.write(dockerfile_string.format(project_name))
+        f.close()
+        with open("{}/Dockerfile".format(ogre_dir), "r+") as f:
+            content = f.read()
+            f.seek(0, 0)
+            f.write("FROM {}".format(baseimage) + content)
+        f.close()
+
     else:
 
         if os.path.isfile("{}/Dockerfile".format(project_dir)):
@@ -110,7 +141,7 @@ def config_dockerfile(project_dir, project_name, ogre_dir,
                 f.write("FROM {}".format(baseimage) + content)
                 # Find last line
                 f.seek(0, 2)
-                #while f.read(1) != b'\n':
+                # while f.read(1) != b'\n':
                 #    f.seek(-2, 1)
                 f.write("{}".format(REQUIREMENTS_LINE))
             f.close()
@@ -124,16 +155,23 @@ def config_baseimage():
     baseimage = (os.getenv("OGRE_BASEIMAGE", OGRE_BASEIMAGE)).format(platform_machine)
 
     return baseimage
-    
+
+
 def config_requirements(project_dir, ogre_dir, force=False):
 
     # Check if requirements.txt is in the root folder
     if os.path.isfile("{}/requirements.txt".format(project_dir)):
         if force:
-            print("   requirements.txt exists in {}, but it will be OVERWRITTEN".format(project_dir))
+            print(
+                "   requirements.txt exists in {}, but it will be OVERWRITTEN".format(
+                    project_dir
+                )
+            )
             return True
         print("   requirements.txt already exists and it will be reused.")
-        os.popen("cp {}/requirements.txt {}/requirements.txt".format(project_dir, ogre_dir))
+        os.popen(
+            "cp {}/requirements.txt {}/requirements.txt".format(project_dir, ogre_dir)
+        )
         res = False
     else:
         print("   requirements.txt does not exist. miniogre will create one for you.")

--- a/miniogre/constants.py
+++ b/miniogre/constants.py
@@ -17,6 +17,18 @@ RUN cp ./ogre_dir/bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 """
 
+DOCKERFILE_BASEIMAGE = """
+ENV TZ=America/Chicago
+WORKDIR /opt/{}
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update && apt-get install -y ttyd
+RUN pip install miniogre
+COPY ./ogre_dir .
+RUN mv ./bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
+CMD ["ttyd", "-p 8008", "bash"]
+"""
+
 BASHRC = """
 _python_argcomplete() {
     local IFS=$'\013'
@@ -193,16 +205,9 @@ GEMINI_MODEL = "gemini-1.5-flash-latest"
 # OLLAMA_MODEL = "mistral:7b"
 OLLAMA_MODEL = "phi3"
 OLLAMA_API_SERVER = "http://localhost:11434/v1"
-# OLLAMA_SECRET_PROMPT = '''You are a Python requirements generator.
-# You should generate the contents of a Python requirements file (raw text only) taking into account the text sent by the user.
-# The raw text sent by the user consists of a combination of the README file contents and the source code contents.
-# You generate only the file contents as answer.
-# If the text sent by the user is invalid or is empty, just generate an empty content.
-# You should ignore the Python version 2 or 3.
-# The python package should not be included in the requirements file.
-# Note that some packages do not exist in the PyPi repository, they are only local, and thus shouldnt be added to the requirements.txt file.
-# Ignore the following Python packages: git, jittor, cuda, shihong, nvdiffrast: they do not exist on the PyPi repository.
-# Your output should be a raw ASCII text file.'''
+
+OGRE_MODEL = "llama3.1"
+OGRE_API_SERVER = "https://llm.ogre.run/v1"
 
 OCTOAI_MODEL = "mistral-7b-instruct-fp16"
 OCTOAI_SECRET_PROMPT = """You are a Python requirements generator.

--- a/miniogre/constants.py
+++ b/miniogre/constants.py
@@ -19,7 +19,7 @@ RUN chmod a+rwx /etc/bash.bashrc
 
 DOCKERFILE_BASEIMAGE = """
 ENV TZ=America/Chicago
-WORKDIR /opt/{}
+WORKDIR /home/{}
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && apt-get install -y ttyd
 RUN pip install miniogre
@@ -71,7 +71,7 @@ echo -e "\e[0;33m"
 
 echo "
 Made by ogre.run, Inc.
-
+More info here: https://ogre.run
 Reach out to us: contact@ogre.run
 "
 
@@ -81,6 +81,7 @@ Reach out to us: contact@ogre.run
 # Aliases
 alias python="python3"
 """
+
 
 FILE_EXTENSIONS = {
     "python": [".py"],

--- a/miniogre/main.py
+++ b/miniogre/main.py
@@ -169,7 +169,7 @@ def build_ogre_image(
 
     config_bashrc_baseimage(ogre_dir_path)
     config_dockerfile(
-        project_path, "my_project", ogre_dir_path, baseimage, dry=False, base=True
+        project_path, "user", ogre_dir_path, baseimage, dry=False, base=True
     )
     build_docker_image(
         os.path.join(ogre_dir_path, "Dockerfile"),

--- a/miniogre/main.py
+++ b/miniogre/main.py
@@ -145,5 +145,41 @@ def spinup(port_map: str = "8001:8001"):
     end_emoji()
 
 
+@app.command()
+def build_ogre_image(
+    baseimage: str = "auto",
+    image_name: str = "baseimage",
+    verbose: bool = False,
+    cache: bool = False,
+    host_platform: str = None,
+):
+    """
+    Build miniogre baseimage
+    """
+
+    display_figlet()
+    starting_emoji()
+
+    if baseimage == "auto":
+        baseimage = config_baseimage()
+
+    ogre_dir_path = config_ogre_dir(
+        os.path.join(project_path, os.getenv("OGRE_DIR", OGRE_DIR))
+    )
+
+    config_bashrc_baseimage(ogre_dir_path)
+    config_dockerfile(
+        project_path, "my_project", ogre_dir_path, baseimage, dry=False, base=True
+    )
+    build_docker_image(
+        os.path.join(ogre_dir_path, "Dockerfile"),
+        image_name,
+        host_platform,
+        verbose,
+        cache,
+    )
+    end_emoji()
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Ogre LLM provider

This feature adds `ogre` to the the list of LLM providers that can be used with option `--provider`. The default provider is still Google's Gemini Pro, but now users can point to the ogre LLM provider that is currently running `llama3.1`.

Full command to use the `ogre` provider within the run pipeline:

`miniogre run --provider ogre`